### PR TITLE
Refactor Mojang API with Client interface

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -1,0 +1,68 @@
+package http
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/valyala/fasthttp"
+)
+
+var (
+	ErrRequestFailed = errors.New("failed to send HTTP request")
+)
+
+type Client interface {
+	SendHTTP(Request) (Response, error)
+}
+
+type Request struct {
+	Method      string
+	URL         string
+	RequestBody []byte
+}
+
+type Response struct {
+	Status int
+	Body   []byte
+}
+
+type fasthttpClient struct{ fasthttp.Client }
+
+func NewDefaultClient() Client {
+	return &fasthttpClient{Client: fasthttp.Client{
+		ReadTimeout:                   1 * time.Second,
+		WriteTimeout:                  1 * time.Second,
+		MaxIdleConnDuration:           1 * time.Hour,
+		NoDefaultUserAgentHeader:      true,
+		DisableHeaderNamesNormalizing: true,
+		Dial: (&fasthttp.TCPDialer{
+			Concurrency:      4096,
+			DNSCacheDuration: 1 * time.Hour,
+		}).Dial,
+	}}
+}
+
+func (f *fasthttpClient) SendHTTP(config Request) (Response, error) {
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+
+	req.Header.SetMethod(config.Method)
+	req.SetRequestURI(config.URL)
+
+	req.Header.Set("Accept", "application/json")
+
+	if config.RequestBody != nil {
+		req.Header.SetContentType("application/json")
+		req.SetBody(config.RequestBody)
+	}
+
+	res := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(res)
+
+	if err := fasthttp.Do(req, res); err != nil {
+		return Response{}, fmt.Errorf("%w: %s", ErrRequestFailed, err)
+	}
+
+	return Response{Status: res.StatusCode(), Body: res.Body()}, nil
+}

--- a/pkg/mojang/api.go
+++ b/pkg/mojang/api.go
@@ -1,21 +1,15 @@
 package mojang
 
 import (
-	"errors"
 	"fmt"
-	"time"
 
-	"github.com/valyala/fasthttp"
-)
-
-var (
-	ErrHTTPSend = errors.New("failed to send HTTP request")
+	"github.com/dreamscached/skind/pkg/http"
 )
 
 type API struct {
 	sessionServer     string
 	minecraftServices string
-	client            *fasthttp.Client
+	client            http.Client
 }
 
 func MustNewAPI(options ...APIOption) *API {
@@ -44,17 +38,7 @@ func newDefaultAPI() *API {
 	return &API{
 		sessionServer:     "https://sessionserver.mojang.com",
 		minecraftServices: "https://api.minecraftservices.com",
-		client: &fasthttp.Client{
-			ReadTimeout:                   1 * time.Second,
-			WriteTimeout:                  1 * time.Second,
-			MaxIdleConnDuration:           1 * time.Hour,
-			NoDefaultUserAgentHeader:      true,
-			DisableHeaderNamesNormalizing: true,
-			Dial: (&fasthttp.TCPDialer{
-				Concurrency:      4096,
-				DNSCacheDuration: 1 * time.Hour,
-			}).Dial,
-		},
+		client:            http.NewDefaultClient(),
 	}
 }
 
@@ -74,7 +58,7 @@ func WithMinecraftServices(baseURL string) APIOption {
 	}
 }
 
-func WithHTTPClient(client *fasthttp.Client) APIOption {
+func WithHTTPClient(client http.Client) APIOption {
 	return func(api *API) error {
 		api.client = client
 		return nil


### PR DESCRIPTION
Adds `http.Client` for possible future use in tests.